### PR TITLE
Add USER validation and update mount options

### DIFF
--- a/internal/mount_bandicoot.sh
+++ b/internal/mount_bandicoot.sh
@@ -87,7 +87,7 @@ case "$OS" in
             exit 1
         fi
         if [ -z "$USER" ]; then
-            echo "USER not defined, please define" > &2
+            echo "USER not defined, please define" >&2
             exit 1
         fi
         # Mount the share with domainauto for automatic domain selection


### PR DESCRIPTION
Adds the mount path the user's `uid` and `gid` so writing can occur. This change helps to side-step CIFS error of modifying file timestamps and deleting partial files during rclone `sync` or `clone`.