### PR TITLE
Update GitHub strategy to include agentic PR's

### DIFF
--- a/github_strategy.md
+++ b/github_strategy.md
@@ -40,7 +40,7 @@ We follow standard procedures when writing software packages including:
 
 - Gallery outlining example use cases
 
-Examples: [pycytominer](https://github.com/cytomining/pycytominer), [CytoSnake](https://github.com/WayScience/CytoSnake)
+Examples: [pycytominer](https://github.com/cytomining/pycytominer), [coSMicQC](https://github.com/cytomining/coSMicQC)
 
 ### 2. Analysis repository
 

--- a/github_strategy.md
+++ b/github_strategy.md
@@ -135,7 +135,7 @@ This process has many direct and indirect benefits.
 
    - The smaller the better; it is WAY easier to review if small
 
-1. **Agentic PRs:** If a pull request is created by a non-human actor (e.g., an agent or LLM model), treat it as a human-authored PR for review purposes. The person who initiated the agent action is considered the author (alongside the agent) and the PR still benefits from outside review by others.
+1. **Agentic PRs:** If a pull request is created by a non-human actor (e.g., an agent or LLM model), treat it as a human-authored PR for review purposes. The person who initiated the agent action is considered the author (alongside the agent) and the PR still benefits from outside review by others. One outside approval is still required for merging.
 
 1. The writer adds details to the pull request in markdown format
 

--- a/github_strategy.md
+++ b/github_strategy.md
@@ -135,6 +135,8 @@ This process has many direct and indirect benefits.
 
    - The smaller the better; it is WAY easier to review if small
 
+1. **Agentic PRs:** If a pull request is created by a non-human actor (e.g., an agent or LLM model), treat it as a human-authored PR for review purposes. The person who initiated the agent action is considered the author (alongside the agent) and the PR still benefits from outside review by others.
+
 1. The writer adds details to the pull request in markdown format
 
    - Justifies the rationale for why the pull request exists


### PR DESCRIPTION
This PR updates the lab GitHub strategy to include agentic PR considerations for clarification. I also took a moment to update software references.

Closes #21
Closes #20 